### PR TITLE
React 16 compatibility + loosen dependencies and use TPT fork of fakequery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,11 @@ A date/time picker for react (using bootstrap). This is a react port of:
 var React = require('react');
 var moment = require('moment');
 var DateRangePicker = require('react-bootstrap-daterangepicker');
-var someReactComponent = React.createClass({
-    render: function () {
-        return (
-            <DateRangePicker startDate={moment('1/1/2014')} endDate={moment('3/1/2014')}>
-                <div>Click Me To Open Picker!</div>
-            </DateRangePicker>
-        );
-    }
-});
+var someReactComponent = () => (
+    <DateRangePicker startDate={moment('1/1/2014')} endDate={moment('3/1/2014')}>
+        <div>Click Me To Open Picker!</div>
+    </DateRangePicker>
+);
 ```
 
 3) Include the daterangepicker CSS in your project somewhere. The CSS file is here: [daterangepicker.css](https://raw.githubusercontent.com/skratchdot/react-bootstrap-daterangepicker/master/css/daterangepicker.css) (don't hotlink- download and host your own copy)

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,13 @@
  * Original copyright in: ./lib/daterangepicker.js
  */
 var React = require('react');
+var createClass = require('create-react-class');
 var DateRangePicker = require('./daterangepicker.js');
 var getOptions = require('./get-options.js');
 var $ = require('fakequery');
 
 /* this is our export React class */
-module.exports = React.createClass({
+module.exports = createClass({
 	picker: null,
 	options: getOptions(),
 	makeEventHandler: function (eventType) {

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "moment": "2.13.0",
-    "moment-timezone": "0.5.4",
     "fakequery": "git://github.com/peleg/fakeQuery.js.git#v0.0.1"
   },
   "peerDependencies": {
-    "react": ">=0.14.0||>=15.0.0"
+    "react": ">=0.14.0||>=15.0.0",
+    "moment-timezone": "^0.5.13"
   },
   "devDependencies": {
+    "moment-timezone": "^0.5.13",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "fakequery": "git://github.com/peleg/fakeQuery.js.git#v0.0.1"
+    "fakequery": "git://github.com/TeachersPayTeachers/fakeQuery.js.git#v0.0.1"
   },
   "peerDependencies": {
     "react": ">=15.0.0",

--- a/package.json
+++ b/package.json
@@ -20,17 +20,17 @@
     "fakequery": "git://github.com/peleg/fakeQuery.js.git#v0.0.1"
   },
   "peerDependencies": {
-    "react": ">=0.14.0||>=15.0.0",
+    "react": ">=16.0.0",
     "moment-timezone": "^0.5.13"
   },
   "devDependencies": {
-    "moment-timezone": "^0.5.13",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babelify": "^7.2.0",
     "bootstrap": "^3.3.6",
     "cheerio": "^0.20.0",
+    "create-react-class": "^15.6.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-browserify": "^0.5.1",
@@ -42,9 +42,10 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.3",
     "jsxhint": "^0.15.1",
-    "react": "^0.14.7",
+    "moment-timezone": "^0.5.13",
+    "react": "^16.0.0",
     "react-bootstrap": "^0.28.3",
-    "react-dom": "^0.14.7",
+    "react-dom": "^16.0.0",
     "request": "^2.69.0",
     "wordwrap": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "gulp-uglify": "^1.5.3",
     "jsxhint": "^0.15.1",
     "moment-timezone": "^0.5.13",
-    "react": "^16.0.0",
+    "react": "^15.0.0 || ^16.0.0",
     "react-bootstrap": "^0.28.3",
-    "react-dom": "^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "request": "^2.69.0",
     "wordwrap": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fakequery": "git://github.com/peleg/fakeQuery.js.git#v0.0.1"
   },
   "peerDependencies": {
-    "react": ">=16.0.0",
+    "react": ">=15.0.0",
     "moment-timezone": "^0.5.13"
   },
   "devDependencies": {


### PR DESCRIPTION
Just merging in changes we're already using downstream by using the v2.1.5-loosen-deps / 2.1.5-react16compat branches in tpt-frontend dependencies. (See https://github.com/TeachersPayTeachers/tpt-frontend/pull/2831)